### PR TITLE
Filtering of quads in SimpleQuadStore

### DIFF
--- a/src/main/java/be/ugent/rml/store/Quad.java
+++ b/src/main/java/be/ugent/rml/store/Quad.java
@@ -35,37 +35,42 @@ public class Quad implements Comparable<Quad> {
 
     @Override
     public int compareTo(Quad o) {
-        int compareGraph;
-        String oGraph = null;
+        int comparison;
 
-        if (o.getGraph() != null) {
-            oGraph = o.getGraph().toString();
-        }
-
-        if (this.graph == null && oGraph == null) {
-            compareGraph = 0;
+        if (this.graph == null && o.getGraph() == null) {
+            comparison = 0;
         } else {
             if (this.graph == null) {
-                compareGraph = -1;
-            } else if (oGraph == null) {
-                compareGraph = 1;
+                comparison = -1;
+            } else if (o.getGraph() == null) {
+                comparison = 1;
             } else {
-                compareGraph = this.graph.toString().compareTo(oGraph);
+                comparison = this.graph.toString().compareTo(o.getGraph().toString());
             }
         }
-        if (compareGraph == 0) {
-            int compareSubject = this.subject.toString().compareTo(o.getSubject().toString());
-            if (compareSubject == 0) {
-                int comparePredicate = this.predicate.toString().compareTo(o.getPredicate().toString());
-                if (comparePredicate == 0) {
-                    return this.object.toString().compareTo(o.getObject().toString());
+
+        if (comparison == 0) {
+            comparison = compareTerms(this.subject, o.getSubject());
+            if (comparison == 0) {
+                comparison = compareTerms(this.predicate, o.getPredicate());
+                if (comparison == 0) {
+                    return compareTerms(this.object, o.getObject());
+                } else {
+                    return comparison;
                 }
-                return comparePredicate;
             } else {
-                return compareSubject;
+                return comparison;
             }
         } else {
-            return compareGraph;
+            return comparison;
+        }
+    }
+
+    private int compareTerms(Term t1, Term t2) {
+        if (t1 == null || t2 == null) {
+            return 0;
+        } else {
+            return t1.toString().compareTo(t2.toString());
         }
     }
 }

--- a/src/main/java/be/ugent/rml/store/SimpleQuadStore.java
+++ b/src/main/java/be/ugent/rml/store/SimpleQuadStore.java
@@ -52,7 +52,17 @@ public class SimpleQuadStore extends QuadStore {
     }
 
     public List<Quad> getQuads(Term subject, Term predicate, Term object, Term graph) {
-        return quads;
+        Quad quad = new Quad(subject, predicate, object, graph);
+
+        List<Quad> filteredQuads = new ArrayList<>();
+
+        for (Quad q : quads) {
+            if (quad.compareTo(q) == 0) {
+                filteredQuads.add(q);
+            }
+        }
+
+        return filteredQuads;
     }
 
     public List<Quad> getQuads(Term subject, Term predicate, Term object) {

--- a/src/test/java/be/ugent/rml/store/Quad_Test.java
+++ b/src/test/java/be/ugent/rml/store/Quad_Test.java
@@ -1,0 +1,64 @@
+package be.ugent.rml;
+
+import be.ugent.rml.term.Term;
+import be.ugent.rml.term.NamedNode;
+import be.ugent.rml.store.Quad;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class Quad_Test {
+    @Test
+    public void compare_quads_strict() {
+        String s = "http://example.com/s";
+        String p = "http://example.com/p";
+        String o = "http://example.com/o";
+        String g = "http://example.com/g";
+
+        Quad q1 = new Quad(new NamedNode(s), new NamedNode(p), new NamedNode(o), new NamedNode(g));
+        Quad q2 = new Quad(new NamedNode(s), new NamedNode(p), new NamedNode(o), new NamedNode(g));
+
+        assertEquals(0, q1.compareTo(q2));
+    }
+
+    @Test
+    public void compare_quads_different_graphs() {
+        String s = "http://example.com/s";
+        String p = "http://example.com/p";
+        String o = "http://example.com/o";
+        String g1 = "http://example.com/g1";
+        String g2 = "http://example.com/g2";
+
+        Quad q1 = new Quad(new NamedNode(s), new NamedNode(p), new NamedNode(o), new NamedNode(g1));
+        Quad q2 = new Quad(new NamedNode(s), new NamedNode(p), new NamedNode(o), new NamedNode(g2));
+
+        assertEquals(-1, q1.compareTo(q2));
+    }
+
+    @Test
+    public void compare_quads_different_subjects() {
+        String s1 = "http://example.com/s1";
+        String s2 = "http://example.com/s2";
+        String p = "http://example.com/p";
+        String o = "http://example.com/o";
+        String g = "http://example.com/g";
+
+        Quad q1 = new Quad(new NamedNode(s1), new NamedNode(p), new NamedNode(o), new NamedNode(g));
+        Quad q2 = new Quad(new NamedNode(s2), new NamedNode(p), new NamedNode(o), new NamedNode(g));
+
+        assertEquals(-1, q1.compareTo(q2));
+    }
+
+    @Test
+    public void compare_quads_null_terms() {
+        String s = "http://example.com/s";
+        String p = "http://example.com/p";
+        String o = "http://example.com/o";
+        String g = "http://example.com/g";
+
+        Quad q1 = new Quad(null,             new NamedNode(p), new NamedNode(o), new NamedNode(g));
+        Quad q2 = new Quad(new NamedNode(s), new NamedNode(p), null,             new NamedNode(g));
+
+        assertEquals(0, q1.compareTo(q2));
+    }
+}

--- a/src/test/java/be/ugent/rml/store/SimpleQuadStore_Test.java
+++ b/src/test/java/be/ugent/rml/store/SimpleQuadStore_Test.java
@@ -1,0 +1,30 @@
+package be.ugent.rml;
+
+import be.ugent.rml.term.Term;
+import be.ugent.rml.term.NamedNode;
+import be.ugent.rml.store.Quad;
+import be.ugent.rml.store.SimpleQuadStore;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class SimpleQuadStore_Test {
+    @Test
+    public void get_filtered_quads() {
+        String s = "http://example.com/s";
+        String p1 = "http://example.com/p1";
+        String p2 = "http://example.com/p2";
+        String o = "http://example.com/o";
+
+        SimpleQuadStore store = new SimpleQuadStore();
+
+        store.addQuad(new NamedNode(s), new NamedNode(p1), new NamedNode(o), null);
+        store.addQuad(new NamedNode(s), new NamedNode(p2), new NamedNode(o), null);
+
+        // get all quads
+        assertEquals(2, store.getQuads(null, null, null).size());
+
+        // get quads matching the predicate
+        assertEquals(1, store.getQuads(null, new NamedNode(p1), null).size());
+    }
+}


### PR DESCRIPTION
Hi! I've implemented filtering for `SimpleQuadStore.getQuads()`, which was causing invalid behaviour in `Initializer.getAllTriplesMaps()` (and others), when `SimpleQuadStore` is used as the backend store, instead of `RDF4JStore`.

`SimpleQuadStore` is a default option and it works faster for me than `RDF4JStore`, so... here you go 😄 