### PR TITLE
Modified RecordsFactory to allow passing source data as InputStream, …

### DIFF
--- a/src/main/java/be/ugent/rml/Utils.java
+++ b/src/main/java/be/ugent/rml/Utils.java
@@ -195,6 +195,10 @@ public class Utils {
         return location.startsWith("https://") || location.startsWith("http://");
     }
 
+    public static boolean isLabeledFile(String location) {
+        return location.startsWith("label://");
+    }
+    
     public static List<Term> getSubjectsFromQuads(List<Quad> quads) {
         ArrayList<Term> subjects = new ArrayList<>();
 

--- a/src/main/java/be/ugent/rml/records/CSVW.java
+++ b/src/main/java/be/ugent/rml/records/CSVW.java
@@ -35,6 +35,10 @@ class CSVW {
         this.is = Utils.getInputStreamFromLocation(path, new File(cwd), getContentType());
     }
     
+    CSVW(InputStream inputStream) throws IOException {
+        this.is = inputStream;
+    }
+    
     private String helper(String term) {
         List<Term> terms = Utils.getObjectsFromQuads(this.rmlStore.getQuads(this.dialect, new NamedNode(NAMESPACES.CSVW + term), null));
         if (!terms.isEmpty()) {

--- a/src/main/java/be/ugent/rml/records/IteratorFormat.java
+++ b/src/main/java/be/ugent/rml/records/IteratorFormat.java
@@ -23,6 +23,10 @@ public abstract class IteratorFormat {
         return _get(stream, iterator);
     }
 
+    public List<Record> get(InputStream stream, String iterator) throws IOException {
+        return _get(stream, iterator);
+    }    
+    
     abstract List<Record> _get(InputStream stream, String iterator) throws IOException;
 
     abstract String getContentType();


### PR DESCRIPTION
…instead of reading them from file or from remote url.

RecordsFactory can accept a Map<named_stream,InputStream>, where named_stream has the format "label://sourcename" and match with the source value in the mapping file.

This way the RML mapper works accepting a mapping file plus a map of named inputs, and can work with in-memory data instead of fetching from pre-defined file/url locations.