### PR TITLE
Fixed issue #111

### DIFF
--- a/src/test/resources/test-cases/RMLTC0010c-CSV/mapping.ttl
+++ b/src/test/resources/test-cases/RMLTC0010c-CSV/mapping.ttl
@@ -19,5 +19,5 @@
 
   rr:predicateObjectMap [
     rr:predicate ex:code ;
-    rr:objectMap [ rr:template "\{\{\{ {ISO 3166} \}\}\}"; rr:termType rr:Literal]
+    rr:objectMap [ rr:template "\\{\\{\\{ {ISO 3166} \\}\\}\\}"; rr:termType rr:Literal]
   ] .

--- a/src/test/resources/test-cases/RMLTC0010c-JSON/mapping.ttl
+++ b/src/test/resources/test-cases/RMLTC0010c-JSON/mapping.ttl
@@ -20,5 +20,5 @@
 
   rr:predicateObjectMap [
     rr:predicate ex:code ;
-    rr:objectMap [ rr:template "\{\{\{ {ISO 3166} \}\}\}"; rr:termType rr:Literal]
+    rr:objectMap [ rr:template "\\{\\{\\{ {ISO 3166} \\}\\}\\}"; rr:termType rr:Literal]
   ] .

--- a/src/test/resources/test-cases/RMLTC0010c-MySQL/mapping.ttl
+++ b/src/test/resources/test-cases/RMLTC0010c-MySQL/mapping.ttl
@@ -21,7 +21,7 @@
 
   rr:predicateObjectMap [
     rr:predicate ex:code ;
-    rr:objectMap [ rr:template "\{\{\{ {ISO 3166} \}\}\}"; rr:termType rr:Literal]
+    rr:objectMap [ rr:template "\\{\\{\\{ {ISO 3166} \\}\\}\\}"; rr:termType rr:Literal]
   ] .
 
 <#DB_source> a d2rq:Database;

--- a/src/test/resources/test-cases/RMLTC0010c-PostgreSQL/mapping.ttl
+++ b/src/test/resources/test-cases/RMLTC0010c-PostgreSQL/mapping.ttl
@@ -21,7 +21,7 @@
 
   rr:predicateObjectMap [
     rr:predicate ex:code ;
-    rr:objectMap [ rr:template "\{\{\{ {ISO 3166} \}\}\}"; rr:termType rr:Literal]
+    rr:objectMap [ rr:template "\\{\\{\\{ {ISO 3166} \\}\\}\\}"; rr:termType rr:Literal]
   ] .
 
 <#DB_source> a d2rq:Database;

--- a/src/test/resources/test-cases/RMLTC0010c-SQLServer/mapping.ttl
+++ b/src/test/resources/test-cases/RMLTC0010c-SQLServer/mapping.ttl
@@ -21,7 +21,7 @@
 
   rr:predicateObjectMap [
     rr:predicate ex:code ;
-    rr:objectMap [ rr:template "\{\{\{ {ISO 3166} \}\}\}"; rr:termType rr:Literal]
+    rr:objectMap [ rr:template "\\{\\{\\{ {ISO 3166} \\}\\}\\}"; rr:termType rr:Literal]
   ] .
 
 <#DB_source> a d2rq:Database;

--- a/src/test/resources/test-cases/RMLTC0010c-XML/mapping.ttl
+++ b/src/test/resources/test-cases/RMLTC0010c-XML/mapping.ttl
@@ -20,5 +20,5 @@
 
   rr:predicateObjectMap [
     rr:predicate ex:code ;
-    rr:objectMap [ rr:template "\{\{\{ {ISO3166} \}\}\}"; rr:termType rr:Literal]
+    rr:objectMap [ rr:template "\\{\\{\\{ {ISO3166} \\}\\}\\}"; rr:termType rr:Literal]
   ] .


### PR DESCRIPTION
> literal curly brace should be double backslash escaped "\\{" instead of "\{"