### PR TITLE
Add Base IRI to objects with relative IRIs

### DIFF
--- a/src/main/java/be/ugent/rml/Executor.java
+++ b/src/main/java/be/ugent/rml/Executor.java
@@ -229,6 +229,27 @@ public class Executor {
 
 
         if (subject != null && predicate != null & object != null) {
+            if (object.getTerm() instanceof NamedNode) {
+                String iri = ((NamedNode) object.getTerm()).getValue();
+                if (Utils.isRelativeIRI(iri)) {
+                    // Check the base IRI to see if we can use it to turn the IRI into an absolute one.
+                    if (this.baseIRI == null) {
+                        logger.error("The base IRI is null, so relative IRI of object cannot be turned in to absolute IRI. Skipped.");
+                        return;
+                    } else {
+                        logger.debug("The IRI of object is made absolute via base IRI.");
+                        iri = this.baseIRI + iri;
+
+                        // Check if the new absolute IRI is valid.
+                        if (Utils.isValidIRI(iri)) {
+                            object = new ProvenancedTerm(new NamedNode(iri), object.getMetadata());
+                        } else {
+                            logger.error("The object \"" + iri + "\" is not a valid IRI. Skipped.");
+                            return;
+                        }
+                    }
+                }
+            }
             this.resultingQuads.addQuad(subject.getTerm(), predicate.getTerm(), object.getTerm(), g);
         }
     }


### PR DESCRIPTION
Hi everyone,
the R2RML specification says the base IRI is added to a term if the term map's term type is rr:IRI and the IRI is relative. As far as I understand, in the current version, this behavior is implemented only with respect to subjects so I modified the Executor to behave similarly also for named objects. Please let me know if the behavior described is correct and, eventually if the proposed changes can be the right way to introduce the modification. I tested it and it seems to behave as expected.