### PR TITLE
Print descriptive error when mapping file does not exist or is invalid Turtle, fixes #54

### DIFF
--- a/src/main/java/be/ugent/rml/cli/Main.java
+++ b/src/main/java/be/ugent/rml/cli/Main.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
+import org.eclipse.rdf4j.rio.RDFParseException;
 
 import java.io.*;
 import java.time.Instant;
@@ -171,7 +172,12 @@ public class Main {
 
                 // Read mapping file.
                 RDF4JStore rmlStore = new RDF4JStore();
-                rmlStore.read(is, null, RDFFormat.TURTLE);
+                try {
+                    rmlStore.read(is, null, RDFFormat.TURTLE);
+                }
+                catch (RDFParseException e) {
+                    logger.error(fatal, "Unable to parse mapping rules as Turtle. Does the file exist and is it valid Turtle?", e);
+                }
 
                 // Convert mapping file to RML if needed.
                 MappingConformer conformer = new MappingConformer(rmlStore, mappingOptions);


### PR DESCRIPTION
# Description

When the mapping rule file path is invalid, the RMLMapper didn't print a descriptive error.
Instead, a parsing error was thrown.

This error is now catched and a proper error message is printed to the console.

# Issues

Fixes #54 