### PR TITLE
Better working Maven artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,8 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.2.1</version>
                 <configuration>
-                    <shadedArtifactAttached>false</shadedArtifactAttached>
+			  <shadedArtifactAttached>true</shadedArtifactAttached>
+			  <shadedClassifierName>all</shadedClassifierName>
                     <transformers>
                         <transformer
                                 implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">


### PR DESCRIPTION
With the original configuration, the shade plugin replaces the regular jar file as the Maven artifact.  This makes the Maven artifact virtually useless for use as a library (e.g., it bundles a slf4j logback binding and it embeds 65 MB of libraries that may not be needed and which can cause conflict).

This pull request attached the fat jar as an extra artifact, allowing the library to be used as a regular Maven artifact.  The fat jar is instead attached using the "all" classifier.