### PR TITLE
FnO: provide better error messages if description is incomplete

### DIFF
--- a/src/main/java/be/ugent/rml/functions/FunctionLoader.java
+++ b/src/main/java/be/ugent/rml/functions/FunctionLoader.java
@@ -197,7 +197,11 @@ public class FunctionLoader {
         }
 
 
-        List<Term> outputs = Utils.getList(this.functionDescriptionTriples, Utils.getObjectsFromQuads(FunctionUtils.getQuadsByFunctionPrefix(this.functionDescriptionTriples, iri, "returns", null)).get(0));
+        List<Term> returns = Utils.getObjectsFromQuads(FunctionUtils.getQuadsByFunctionPrefix(this.functionDescriptionTriples, iri, "returns", null));
+        if (returns.isEmpty()) {
+            throw new IOException("Missing " + NAMESPACES.FNO_S + "returns for " + iri + " in the function descriptions.");
+        }
+        List<Term> outputs = Utils.getList(this.functionDescriptionTriples, returns.get(0));
 
         List<Term> methodMappings = Utils.getObjectsFromQuads(FunctionUtils.getQuadsByFunctionPrefix(this.functionDescriptionTriples, mappings.get(0), "methodMapping", null));
         if (methodMappings.size() == 0) {

--- a/src/main/java/be/ugent/rml/functions/FunctionUtils.java
+++ b/src/main/java/be/ugent/rml/functions/FunctionUtils.java
@@ -56,12 +56,17 @@ public class FunctionUtils {
         return parameterPredicates;
     }
 
-    public static Class<?>[] parseFunctionParameters(QuadStore store, List<Term> parameterResources) {
+    public static Class<?>[] parseFunctionParameters(QuadStore store, List<Term> parameterResources)
+            throws IOException {
         Class<?>[] args = new Class<?>[parameterResources.size()];
 
         for (int i = 0; i < parameterResources.size(); i++) {
             Term subject = parameterResources.get(i);
-            Term type = Utils.getObjectsFromQuads(getQuadsByFunctionPrefix(store, subject, "type", null)).get(0);
+            List<Term> types = Utils.getObjectsFromQuads(getQuadsByFunctionPrefix(store, subject, "type", null));
+            if (types.isEmpty()) {
+                throw new IOException("Missing " + NAMESPACES.FNO_S + "type for " + subject + " in function descriptions.");
+            }
+            Term type = types.get(0);
 
             try {
                 args[i] = FunctionUtils.getParamType(type);


### PR DESCRIPTION
Motivation:

If certain key information is missing from the FnO description then
rmlmapper reacts by returning an error message like:

    Index 0 out of bounds for length 0

This error message provides no information about what is wrong, so the
user has no way to understand how to fix the problem.

Modification:

Check that the predicate query returns at least one result before
attempting to extract the expected result from the list.  Throw an
exception with a meaningful error message if the search yields results;
for example:

    <https://github.com/paulmillar/rml-extra-functions#param_base_uri> is missing https://w3id.org/function/ontology#type

Result:

The code provides a better error message if the FnO description is
incomplete.