### PR TITLE
CSV: add support for csvw:null

### DIFF
--- a/src/main/java/be/ugent/rml/records/CSVW.java
+++ b/src/main/java/be/ugent/rml/records/CSVW.java
@@ -82,6 +82,7 @@ class CSVW {
                     // @type
                     // withQuoteChar
                     .withQuote(getQuoteCharacter())
+                    .withNullString(getNullString())
             ;
 
             // Encoding
@@ -189,6 +190,20 @@ class CSVW {
             return this.csvFormat.getQuoteCharacter();
         } else {
             return output.toCharArray()[0];
+        }
+    }
+
+    /**
+     * This method returns the string that indicates a null value.
+     * @return the null string.
+     */
+    private String getNullString() {
+        String output = getValueFromTerm("null");
+
+        if (output == null) {
+            return this.csvFormat.getNullString();
+        } else {
+            return output;
         }
     }
 }


### PR DESCRIPTION
Motivation:

In tabular data representations, one problem is how to represent the
absence of information; for example, if a field not apply to all rows
what value should be placed in the cell where the information is either
missing or not applicable?

A common solution is to use a place-holder value that represents the
absence of information.  Examples of such place-holder values include
the empty string (""), a dash ("-") or a phrase (or abbreviation
thereof) such as "N.A.".

It would be useful if such place-holder values were identified as such
and RMLMapper refrained for making any corresponding assertions.

The CSVW namespace [1] provides metadata describing a CSV file.  Within
RMLMapper, this may be used to configure the CSV parser.  One feature of
CSVW is its ability to describe how certain values correspond to the
`null` value.  This is useful as RMLMapper will not include triples
where the object value is `null`.

Although RMLMapper provides partial support for CSVW, this currently
lacks support for `csvw:null` assertions.

[1] https://www.w3.org/ns/csvw

Modification:

Add limited support for `csvw:null` assertions.

CSVW supports potentially multiple `csvw:null` assertions; however,
Commons CSV parser only supports a single `null` String (see [2]).
Therefore, support for `csvw:null` is only partial.

[2] https://issues.apache.org/jira/browse/CSV-293

Result:

A CSV-backed mapping may now be defined with a specific string
identified as a place-holder indicating missing information.  If a cell
contains the place-holder value then any corresponding assertions are
suppressed.  This is achieved using the `csvw:null` assertion; however,
please note that current support is limited to a single `csvw:null`
assertion; any subsequent assertions are silently ignored.