### PR TITLE
Add support for XPath v2 and v3 with Saxon-HE library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ ojdbc*.jar
 pom-oracle.xml
 dependency-reduced-pom.xml
 settings.xml
+.classpath
+.project

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,12 @@
             <artifactId>jaxp-api</artifactId>
             <version>1.4.5</version>
         </dependency>
+        <!-- Saxon Home Edition XML, XPath and XQuery parser API -->
+        <dependency>
+            <groupId>net.sf.saxon</groupId>
+            <artifactId>Saxon-HE</artifactId>
+            <version>11.3</version>
+        </dependency>
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>

--- a/src/main/java/be/ugent/rml/records/RecordsFactory.java
+++ b/src/main/java/be/ugent/rml/records/RecordsFactory.java
@@ -6,7 +6,6 @@ import be.ugent.rml.access.Access;
 import be.ugent.rml.access.AccessFactory;
 import be.ugent.rml.store.Quad;
 import be.ugent.rml.store.QuadStore;
-import be.ugent.rml.target.TargetFactory;
 import be.ugent.rml.term.NamedNode;
 import be.ugent.rml.term.Term;
 import org.slf4j.Logger;

--- a/src/main/java/be/ugent/rml/records/XMLRecord.java
+++ b/src/main/java/be/ugent/rml/records/XMLRecord.java
@@ -3,16 +3,10 @@ package be.ugent.rml.records;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import be.ugent.rml.records.xpath.NamespaceResolver;
-
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
+import net.sf.saxon.s9api.SaxonApiException;
+import net.sf.saxon.s9api.XPathCompiler;
+import net.sf.saxon.s9api.XdmItem;
+import net.sf.saxon.s9api.XdmValue;
 
 /**
  * This class is a specific implementation of a record for XML.
@@ -20,10 +14,13 @@ import javax.xml.xpath.XPathFactory;
  */
 public class XMLRecord extends Record {
 
-    private Node node;
+    private XdmItem item;
+    private XPathCompiler compiler;
 
-    public XMLRecord(Node node) {
-        this.node = node;
+    public XMLRecord(XdmItem item, XPathCompiler compiler) {
+        this.item = item;
+        // Keep a reference to the XPath compiler for faster future queries
+        this.compiler = compiler;
     }
 
     /**
@@ -35,21 +32,14 @@ public class XMLRecord extends Record {
     @Override
     public List<Object> get(String value) {
         List<Object> results = new ArrayList<>();
-        XPath xPath = XPathFactory.newInstance().newXPath();
-        xPath.setNamespaceContext(new NamespaceResolver(this.node.getOwnerDocument()));
-        try {
-            NodeList result = (NodeList) xPath.compile(value).evaluate(node, XPathConstants.NODESET);
 
-            for (int i = 0; i < result.getLength(); i++) {
-                results.add(result.item(i).getTextContent());
-            }
-        } catch (XPathExpressionException e1) {
-            /* Fallback to string representation if not a nodeset. */
-            try {
-                results.add((String) xPath.compile(value).evaluate(node));
-            } catch (XPathExpressionException e2) {
-                e2.printStackTrace();
-            }
+        try {
+            XdmValue result = compiler.evaluate(value, item);
+            result.forEach((node) -> {
+                results.add(node.getStringValue());  
+            });
+        } catch (SaxonApiException e1) {
+            e1.printStackTrace();
         }
 
 

--- a/src/main/java/be/ugent/rml/records/XMLRecordFactory.java
+++ b/src/main/java/be/ugent/rml/records/XMLRecordFactory.java
@@ -1,14 +1,11 @@
 package be.ugent.rml.records;
 
 import net.sf.saxon.s9api.Processor;
-import net.sf.saxon.functions.FunctionLibraryList;
-import net.sf.saxon.functions.registry.ConstructorFunctionLibrary;
 import net.sf.saxon.s9api.DocumentBuilder;
 import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.XPathCompiler;
 import net.sf.saxon.s9api.XdmNode;
 import net.sf.saxon.s9api.XdmValue;
-import net.sf.saxon.sxpath.IndependentContext;
 
 import javax.xml.transform.stream.StreamSource;
 
@@ -45,15 +42,6 @@ public class XMLRecordFactory extends IteratorFormat<XdmNode> {
 
         try {
             XPathCompiler compiler = saxProcessor.newXPathCompiler();
-            // Redefine compiler's supported function libraries to include XSLT 3.0 functions
-            IndependentContext env = (IndependentContext) compiler.getUnderlyingStaticContext();
-            FunctionLibraryList lib = new FunctionLibraryList();
-            lib.addFunctionLibrary(env.getConfiguration().getXSLT30FunctionSet()); // This one is missing in default context
-            lib.addFunctionLibrary(env.getConfiguration().getXPath31FunctionSet());
-            lib.addFunctionLibrary(env.getConfiguration().getBuiltInExtensionLibraryList());
-            lib.addFunctionLibrary(new ConstructorFunctionLibrary(env.getConfiguration()));
-            lib.addFunctionLibrary(env.getConfiguration().getIntegratedFunctionLibrary());
-            env.setFunctionLibrary(lib);
             // Enable expression caching
             compiler.setCaching(true);
             // Extract and register existing source namespaces into the XPath compiler

--- a/src/main/java/be/ugent/rml/records/XMLRecordFactory.java
+++ b/src/main/java/be/ugent/rml/records/XMLRecordFactory.java
@@ -1,19 +1,19 @@
 package be.ugent.rml.records;
 
-import org.apache.xmlbeans.impl.xb.xsdschema.FieldDocument.Field.Xpath;
-import org.w3c.dom.Document;
-import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
+import net.sf.saxon.s9api.Processor;
+import net.sf.saxon.functions.FunctionLibraryList;
+import net.sf.saxon.functions.registry.ConstructorFunctionLibrary;
+import net.sf.saxon.s9api.DocumentBuilder;
+import net.sf.saxon.s9api.SaxonApiException;
+import net.sf.saxon.s9api.XPathCompiler;
+import net.sf.saxon.s9api.XdmNode;
+import net.sf.saxon.s9api.XdmValue;
+import net.sf.saxon.sxpath.IndependentContext;
 
-import be.ugent.rml.records.xpath.NamespaceResolver;
+import javax.xml.transform.stream.StreamSource;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
+import be.ugent.rml.records.xpath.SaxNamespaceResolver;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -22,7 +22,14 @@ import java.util.List;
 /**
  * This class is a record factory that creates XML records.
  */
-public class XMLRecordFactory extends IteratorFormat<Document> {
+public class XMLRecordFactory extends IteratorFormat<XdmNode> {
+
+    // Saxon processor to be reused across XPath query evaluations
+    private Processor saxProcessor;
+
+    public XMLRecordFactory() {
+        saxProcessor = new Processor(false);
+    }
 
     /**
      * This method returns the records from an XML document based on an iterator.
@@ -33,17 +40,31 @@ public class XMLRecordFactory extends IteratorFormat<Document> {
      * @throws IOException
      */
     @Override
-    List<Record> getRecordsFromDocument(Document document, String iterator) throws IOException {
+    List<Record> getRecordsFromDocument(XdmNode document, String iterator) throws IOException {
         List<Record> records = new ArrayList<>();
 
         try {
-            XPath xPath = XPathFactory.newInstance().newXPath();
-            xPath.setNamespaceContext(new NamespaceResolver(document));
-            NodeList result = (NodeList) xPath.compile(iterator).evaluate(document, XPathConstants.NODESET);
-            for (int i = 0; i < result.getLength(); i++) {
-                records.add(new XMLRecord(result.item(i)));
-            }
-        } catch (XPathExpressionException e) {
+            XPathCompiler compiler = saxProcessor.newXPathCompiler();
+            // Redefine compiler's supported function libraries to include XSLT 3.0 functions
+            IndependentContext env = (IndependentContext) compiler.getUnderlyingStaticContext();
+            FunctionLibraryList lib = new FunctionLibraryList();
+            lib.addFunctionLibrary(env.getConfiguration().getXSLT30FunctionSet()); // This one is missing in default context
+            lib.addFunctionLibrary(env.getConfiguration().getXPath31FunctionSet());
+            lib.addFunctionLibrary(env.getConfiguration().getBuiltInExtensionLibraryList());
+            lib.addFunctionLibrary(new ConstructorFunctionLibrary(env.getConfiguration()));
+            lib.addFunctionLibrary(env.getConfiguration().getIntegratedFunctionLibrary());
+            env.setFunctionLibrary(lib);
+            // Enable expression caching
+            compiler.setCaching(true);
+            // Extract and register existing source namespaces into the XPath compiler
+            SaxNamespaceResolver.registerNamespaces(compiler, document);
+            // Execute iterator XPath query
+            XdmValue result = compiler.evaluate(iterator, document);
+            // Extract set of records
+            result.forEach((item) -> {
+                records.add(new XMLRecord(item, compiler));
+            });
+        } catch (SaxonApiException e) {
             e.printStackTrace();
         }
 
@@ -58,14 +79,11 @@ public class XMLRecordFactory extends IteratorFormat<Document> {
      * @throws IOException
      */
     @Override
-    Document getDocumentFromStream(InputStream stream) throws IOException {
+    XdmNode getDocumentFromStream(InputStream stream) throws IOException {
         try {
-            DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
-            builderFactory.setNamespaceAware(true);
-            DocumentBuilder builder = builderFactory.newDocumentBuilder();
-
-            return builder.parse(stream);
-        } catch (SAXException | ParserConfigurationException e) {
+            DocumentBuilder docBuilder = saxProcessor.newDocumentBuilder();
+            return docBuilder.build(new StreamSource(stream));
+        } catch (SaxonApiException e) {
             e.printStackTrace();
         }
 

--- a/src/main/java/be/ugent/rml/records/xpath/SaxNamespaceResolver.java
+++ b/src/main/java/be/ugent/rml/records/xpath/SaxNamespaceResolver.java
@@ -1,0 +1,32 @@
+package be.ugent.rml.records.xpath;
+
+import net.sf.saxon.om.NodeInfo;
+import net.sf.saxon.s9api.SaxonApiException;
+import net.sf.saxon.s9api.XPathCompiler;
+import net.sf.saxon.s9api.XdmNode;
+import net.sf.saxon.s9api.XdmValue;
+
+public class SaxNamespaceResolver {
+
+    /**
+     * Hackish method to extract all available namespace definitions
+     * using a XPath expression and declaring them into a XPath Compiler.
+     * 
+     * This should be handled similarly to how it is done in {@link NamespaceResolver},
+     * but in this case by implementing the {@link net.sf.saxon.om.NamespaceResolver} interface
+     * relying on saxon-based utility classes. 
+     */
+    public static void registerNamespaces(XPathCompiler compiler, XdmNode node) {
+        try {
+            String query = "//namespace::*";
+            XdmValue result = compiler.evaluate(query, node);
+
+            result.forEach((item) -> {
+                NodeInfo ns = (NodeInfo) item.getUnderlyingValue();
+                compiler.declareNamespace(ns.getLocalPart(), ns.getStringValue());
+            });
+        } catch (SaxonApiException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/be/ugent/rml/records/xpath/SaxNamespaceResolver.java
+++ b/src/main/java/be/ugent/rml/records/xpath/SaxNamespaceResolver.java
@@ -25,6 +25,12 @@ public class SaxNamespaceResolver {
                 NodeInfo ns = (NodeInfo) item.getUnderlyingValue();
                 compiler.declareNamespace(ns.getLocalPart(), ns.getStringValue());
             });
+
+            // Add additional function namespaces. These should probably be defined as constants. 
+            compiler.declareNamespace("math", "http://www.w3.org/2005/xpath-functions/math");
+            compiler.declareNamespace("map", "http://www.w3.org/2005/xpath-functions/map");
+            compiler.declareNamespace("array", "http://www.w3.org/2005/xpath-functions/array");
+
         } catch (SaxonApiException e) {
             e.printStackTrace();
         }

--- a/src/test/java/be/ugent/rml/Mapper_XML_Test.java
+++ b/src/test/java/be/ugent/rml/Mapper_XML_Test.java
@@ -222,4 +222,9 @@ public class Mapper_XML_Test extends TestCore {
     public void evaluate_1032_XML() {
         doMapping("./test-cases/RMLTC1032-XML/mapping.ttl", "./test-cases/RMLTC1032-XML/output.nq");
     }
+
+    @Test
+    public void evaluate_1033_XML() {
+        doMapping("./test-cases/RMLTC1033-XML/mapping.ttl", "./test-cases/RMLTC1033-XML/output.nq");
+    }
 }

--- a/src/test/java/be/ugent/rml/Mapper_XML_Test.java
+++ b/src/test/java/be/ugent/rml/Mapper_XML_Test.java
@@ -227,4 +227,9 @@ public class Mapper_XML_Test extends TestCore {
     public void evaluate_1033_XML() {
         doMapping("./test-cases/RMLTC1033-XML/mapping.ttl", "./test-cases/RMLTC1033-XML/output.nq");
     }
+
+    @Test
+    public void evaluate_1034_XML() {
+        doMapping("./test-cases/RMLTC1034-XML/mapping.ttl", "./test-cases/RMLTC1034-XML/output.nq");
+    }
 }

--- a/src/test/resources/test-cases/RMLTC1033-XML/data.xml
+++ b/src/test/resources/test-cases/RMLTC1033-XML/data.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<myNS:students xmlns:myNS="https://example.org/NS/my" xmlns="https://example.org/NS/default">
+    <myNS:student>
+        <Name>Alice</Name>
+        <Address>
+            <Street>12th Avenue</Street>
+            <City>New York</City>
+            <Number>254</Number>
+        </Address>
+    </myNS:student>
+    <myNS:student>
+        <Name>Bob</Name>
+        <Address>
+            <Street>15th Avenue</Street>
+            <City>Atlanta</City>
+            <Number>291</Number>
+        </Address>
+    </myNS:student>
+    <myNS:student>
+        <Name>Charles</Name>
+    </myNS:student>
+</myNS:students>

--- a/src/test/resources/test-cases/RMLTC1033-XML/data.xml
+++ b/src/test/resources/test-cases/RMLTC1033-XML/data.xml
@@ -4,16 +4,16 @@
         <Name>Alice</Name>
         <Address>
             <Street>12th Avenue</Street>
-            <City>New York</City>
             <Number>254</Number>
+            <City>New York</City>
         </Address>
     </myNS:student>
     <myNS:student>
         <Name>Bob</Name>
         <Address>
             <Street>15th Avenue</Street>
-            <City>Atlanta</City>
             <Number>291</Number>
+            <City>Atlanta</City>
         </Address>
     </myNS:student>
     <myNS:student>

--- a/src/test/resources/test-cases/RMLTC1033-XML/mapping.ttl
+++ b/src/test/resources/test-cases/RMLTC1033-XML/mapping.ttl
@@ -9,20 +9,34 @@
 
 @base <http://example.com/base/> .
 
+## 
+# Test mapping for some XPath 2.0 expressions and functions (https://www.w3.org/TR/xpath20/):
+# - lower-case()
+# - upper-case()
+# - string-join()
+# - for expression
+# - if-then-else conditional expression
+##
+
 <TriplesMapStudent>
   a rr:TriplesMap;
   rml:logicalSource [
     rml:source "data.xml";
     rml:referenceFormulation ql:XPath;
-    rml:iterator "/myNS:students/myNS:student"
+    rml:iterator "/myNS:students/myNS:student[Address]"
   ];
     
     rr:subjectMap [ rml:reference "Name"; rr:termType rr:IRI; ];
     
     rr:predicateObjectMap [
     	rr:predicate rdfs:label;
-    	rr:objectMap [ rml:reference "lower-case(Name)" ] # XPath 2.0 function lower-case()
+    	rr:objectMap [ rml:reference "lower-case(Name)" ]
     ], [
         rr:predicate ex:city;
-        rr:objectMap [ rml:reference "upper-case(Address/City)" ] # XPath 2.0 function upper-case()
+        rr:objectMap [ rml:reference "upper-case(Address/City)" ]
+    ], [
+        rr:predicate ex:fullAddress;
+        rr:objectMap [ # compile full address with format "${street} ${number}, ${city}" 
+            rml:reference "string-join(for $n in Address/* return (if (name($n) = 'City') then string-join((', ', $n)) else string-join((' ', $n))), '')" 
+        ]
     ].

--- a/src/test/resources/test-cases/RMLTC1033-XML/mapping.ttl
+++ b/src/test/resources/test-cases/RMLTC1033-XML/mapping.ttl
@@ -1,0 +1,28 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml:    <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql:     <http://semweb.mmlab.be/ns/ql#> .
+
+@base <http://example.com/base/> .
+
+<TriplesMapStudent>
+  a rr:TriplesMap;
+  rml:logicalSource [
+    rml:source "data.xml";
+    rml:referenceFormulation ql:XPath;
+    rml:iterator "/myNS:students/myNS:student"
+  ];
+    
+    rr:subjectMap [ rml:reference "Name"; rr:termType rr:IRI; ];
+    
+    rr:predicateObjectMap [
+    	rr:predicate rdfs:label;
+    	rr:objectMap [ rml:reference "lower-case(Name)" ] # XPath 2.0 function lower-case()
+    ], [
+        rr:predicate ex:city;
+        rr:objectMap [ rml:reference "upper-case(Address/City)" ] # XPath 2.0 function upper-case()
+    ].

--- a/src/test/resources/test-cases/RMLTC1033-XML/output.nq
+++ b/src/test/resources/test-cases/RMLTC1033-XML/output.nq
@@ -1,6 +1,6 @@
 <http://example.com/base/Alice> <http://www.w3.org/2000/01/rdf-schema#label> "alice".
 <http://example.com/base/Alice> <http://example.com/city> "NEW YORK".
+<http://example.com/base/Alice> <http://example.com/fullAddress> " 12th Avenue 254, New York".
 <http://example.com/base/Bob> <http://www.w3.org/2000/01/rdf-schema#label> "bob".
 <http://example.com/base/Bob> <http://example.com/city> "ATLANTA".
-<http://example.com/base/Charles> <http://www.w3.org/2000/01/rdf-schema#label> "charles".
-<http://example.com/base/Charles> <http://example.com/city> "".
+<http://example.com/base/Bob> <http://example.com/fullAddress> " 15th Avenue 291, Atlanta".

--- a/src/test/resources/test-cases/RMLTC1033-XML/output.nq
+++ b/src/test/resources/test-cases/RMLTC1033-XML/output.nq
@@ -1,0 +1,6 @@
+<http://example.com/base/Alice> <http://www.w3.org/2000/01/rdf-schema#label> "alice".
+<http://example.com/base/Alice> <http://example.com/city> "NEW YORK".
+<http://example.com/base/Bob> <http://www.w3.org/2000/01/rdf-schema#label> "bob".
+<http://example.com/base/Bob> <http://example.com/city> "ATLANTA".
+<http://example.com/base/Charles> <http://www.w3.org/2000/01/rdf-schema#label> "charles".
+<http://example.com/base/Charles> <http://example.com/city> "".

--- a/src/test/resources/test-cases/RMLTC1034-XML/data.xml
+++ b/src/test/resources/test-cases/RMLTC1034-XML/data.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<railML xmlns="https://www.railml.org/schemas/3.1">
+    <netElements>
+        <netElement id="A" x="1" y="3">
+            <name language="NO" name="NODE-1"/>
+            <relation ref="A_B"/>
+        </netElement>
+        <netElement id="B" x="6" y="8">
+            <name language="NO" name="NODE-2"/>
+            <relation ref="A_B"/>
+        </netElement>
+    </netElements>
+    <netRelations>
+        <netRelation id="A_B">
+            <elementA ref="A"/>
+            <elementB ref="B"/>
+        </netRelation>
+    </netRelations>
+</railML>

--- a/src/test/resources/test-cases/RMLTC1034-XML/mapping.ttl
+++ b/src/test/resources/test-cases/RMLTC1034-XML/mapping.ttl
@@ -1,0 +1,45 @@
+@prefix rr:   <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex:   <http://example.com/> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml:  <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql:   <http://semweb.mmlab.be/ns/ql#> .
+
+@base <http://example.com/base/> .
+
+## 
+# Test mapping for some XPath 3 expressions and functions (https://www.w3.org/TR/xpath-31/):
+# - || concatenation operator
+# - let expressions
+# - math functions abs(), sqrt() and pow()
+##
+
+<TriplesMapRails> a rr:TriplesMap;
+  rml:logicalSource [
+    rml:source "data.xml";
+    rml:referenceFormulation ql:XPath;
+    rml:iterator "//netRelation"
+  ];
+
+  rr:subjectMap [
+    rml:reference "('relations/' || elementA/@ref || '/' || elementB/@ref)"; 
+    rr:termType rr:IRI;
+    rr:class ex:NetRelation
+  ];
+    
+  rr:predicateObjectMap [
+      rr:predicate ex:elementA;
+      rr:objectMap [
+          rr:termType rr:IRI;
+          rr:template "http://example.com/base/elements/{let $ref := elementA/@ref return (ancestor::railML//netElement[@id = $ref])/name/@name}" 
+      ]
+  ], [
+      rr:predicate ex:distance;
+      rr:objectMap [ # calculate euclidean distance based on (x,y) coordinates |sqrt((x2-x1)^2+(y2-y1)^2)|
+          rr:termType rr:Literal;
+          rr:datatype xsd:double;
+          rml:reference "let $refA := elementA/@ref, $refB := elementB/@ref return abs(math:sqrt(math:pow((ancestor::railML//netElement[@id = $refB])/@x - (ancestor::railML//netElement[@id = $refA])/@x, 2) + math:pow((ancestor::railML//netElement[@id = $refB])/@y - (ancestor::railML//netElement[@id = $refA])/@y, 2)))" 
+      ]
+  ].

--- a/src/test/resources/test-cases/RMLTC1034-XML/output.nq
+++ b/src/test/resources/test-cases/RMLTC1034-XML/output.nq
@@ -1,0 +1,3 @@
+<http://example.com/base/relations/A/B> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/NetRelation>.
+<http://example.com/base/relations/A/B> <http://example.com/elementA> <http://example.com/base/elements/NODE-1>.
+<http://example.com/base/relations/A/B> <http://example.com/distance> "7.0710678118654755"^^<http://www.w3.org/2001/XMLSchema#double>.


### PR DESCRIPTION
### What is this?
This PR integrates the [Saxon-HE v11](https://www.saxonica.com/html/documentation11/xpath-api/) library into the mapper, as a XML and XPath parser, to bring support for more advanced XPath capabilities.

### Motivation
Unlike the [currently used XML parser](https://mvnrepository.com/artifact/javax.xml.parsers/jaxp-api/1.4.5), which only supports [XPath v1.0](https://www.w3.org/TR/1999/REC-xpath-19991116/) and a handful of [functions](https://developer.mozilla.org/en-US/docs/Web/XPath/Functions), Saxon supports up to [XPath v3.1](https://www.w3.org/TR/xpath-31/). 

There is a significant difference in terms of expressivity between XPath v1 and v3, which is often needed when generating RDF from XML sources.

### Tests

This PR passes all existing XML test-cases and adds 2 new ones:
- [RMLTC1033-XML](https://github.com/julianrojas87/rmlmapper-java/tree/master/src/test/resources/test-cases/RMLTC1033-XML): tests for simple and complex XPath v2 expressions
- [RMLTC1034-XML](https://github.com/julianrojas87/rmlmapper-java/tree/master/src/test/resources/test-cases/RMLTC1034-XML): tests for simple and complex XPath v3 expressions

It is also able to handle gracefully XML namespaces including this [default namespace issue](https://github.com/RMLio/rmlmapper-java/issues/154). However the implementation [could be improved](https://github.com/julianrojas87/rmlmapper-java/blob/8c11412fe1cb597399bbe847af193d13d290e1cc/src/main/java/be/ugent/rml/records/xpath/SaxNamespaceResolver.java#L12).

### Performance
Saxon is [supposed to be more performant](https://examples.javacodegeeks.com/core-java/xml/xpath/java-xpath-performance-dom-vs-sax-example/#code) than the default Java XML implementation. 

So I tested this build with a relatively large XML source (~300Mb), namely an OpenStreetMap extract for the [city of Ghent](https://download.bbbike.org/osm/bbbike/Gent/Gent.osm.gz) and the results are very promising, both in terms of performance and memory footprint:
- This build **fully maps** the file in ~14s with the default JVM memory limit.
- The current release of RML Mapper ([v5.0.0](https://github.com/RMLio/rmlmapper-java/releases/tag/v5.0.0)) wasn't able to map the file after ~2h and with all the memory available in my laptop (`-Xmx16384m`).

I used the following RML mapping:
```turtle
@prefix rr:   <http://www.w3.org/ns/r2rml#> .
@prefix osm:  <https://w3id.org/openstreetmap/terms#> .
@prefix geo:  <http://www.w3.org/2003/01/geo/wgs84_pos#> .
@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@prefix rml:  <http://semweb.mmlab.be/ns/rml#> .
@prefix ql:   <http://semweb.mmlab.be/ns/ql#> .
@prefix : <http://mapping.example.com/> .

## 
# Benchmark RML mapping file to test the performance or XPath processors.
# It refers to the OpenStreetMap XML export for the city of Ghent 
# from BBBike (https://download.bbbike.org/osm/bbbike/Gent/Gent.osm.gz).
##

:TriplesMapBenchmark a rr:TriplesMap;
  rml:logicalSource [
    rml:source "benchmark/Gent.osm";
    rml:referenceFormulation ql:XPath;
    rml:iterator "osm/node[tag/@k = 'highway' and tag/@v = 'bus_stop']" # select all bus stop nodes
  ];

  rr:subjectMap [
    rr:template "http://osm.example.org/node/{@lat}/{@lon}"; 
    rr:termType rr:IRI;
    rr:class osm:Node
  ];

  rr:predicateObjectMap [
      rr:predicate geo:lat;
      rr:objectMap [
          rr:termType rr:Literal;
          rr:datatype xsd:double;
          rr:template "{@lat}" 
      ]
  ], [
      rr:predicate geo:long;
      rr:objectMap [
          rr:termType rr:Literal;
          rr:datatype xsd:double;
          rr:template "{@lon}" 
      ]
  ],[
      rr:predicate rdfs:label;
      rr:objectMap [ rml:reference "tag[@k = 'name']/@v" ]
  ], [
      rr:predicate osm:operator;
      rr:objectMap [ rml:reference "tag[@k = 'operator']/@v" ]
  ].
``` 
### New possibilities
This integration allows to implement support for [XQuery](https://www.w3.org/TR/xquery-31/), a SQL-like language for XML procesing (already supported by Saxon) and more advanced features of XPath 3, like [JSON querying with XPath](https://www.w3.org/TR/xpath-functions-31/#json-functions). 