### PR TITLE
Add the Jelly output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ and see [Usage](#cli) on how to use the commandline interface!
   - For examples on how to use functions within RML mapping documents, you can have a look at the [RML+FnO test cases](https://github.com/RMLio/rml-fno-test-cases)
 - configuration file
 - metadata generation
-- output formats: nquads (default), turtle, trig, trix, jsonld, hdt
+- output formats: nquads (default), turtle, trig, trix, jsonld, hdt, [jelly](https://w3id.org/jelly)
 - join conditions
 - targets:
   - local file
@@ -104,7 +104,7 @@ The following options are most common.
 
 - `-m, --mapping <arg>`: one or more mapping file paths and/or strings (multiple values are concatenated).
 - `-o, --output <arg>`: path to output file
-- `-s,--serialization <arg>`: serialization format (nquads (default), trig, trix, jsonld, hdt)
+- `-s,--serialization <arg>`: serialization format (nquads (default), trig, trix, jsonld, hdt, [jelly](https://w3id.org/jelly))
 
 All options can be found when executing `java -jar rmlmapper.jar --help`,
 that output is found below.
@@ -148,7 +148,7 @@ options:
                                      passwords, certificates, etc.
  -s,--serialization <arg>            serialization format (nquads
                                      (default), turtle, trig, trix,
-                                     jsonld, hdt)
+                                     jsonld, hdt, jelly)
     --strict                         Enable strict mode. In strict mode,
                                      the mapper will fail on invalid IRIs
                                      instead of skipping them.
@@ -307,31 +307,34 @@ The tests will fail otherwise, as Testcontainers can't spin up the container.
 
 ## Dependencies
 
-|                   Dependency                   | License                                                            |
-|:----------------------------------------------:|--------------------------------------------------------------------|
-|         ch.qos.logback logback-classic         | Eclipse Public License 1.0 & GNU Lesser General Public License 2.1 |
-|      com.github.fnoio function-agent-java      | MIT                                                                |
-|      com.github.fnoio grel-functions-java      | MIT                                                                |
-|     com.github.fnoio idlab-functions-java      | MIT                                                                |
-|           com.github.rdfhdt hdt-java           | GNU Lesser General Public License v3.0                             |
-|      com.github.tomakehurst:wiremock-jre8      | Apache License 2.0                                                 |
-|       com.microsoft.sqlserver mssql-jdbc       | MIT                                                                |
-|         com.mysql mysql-connector-java         | GNU General Public License v2.0                                    |
-|        com.oracle.database.jdbc:ojdbc11        | Oracle Free Use Terms and Conditions                               |
-|             net.minidev json-smart             | Apache License 2.0                                                 |
-|          org.apache.jena fuseki-main           | Apache License 2.0                                                 |
-|         org.eclipse.rdf4j rdf4j-client         | Eclipse Distribution License v1.0                                  |
-|      org.junit.jupiter junit-jupiter-api       | Eclipse Public License v2.0                                        |
-|     org.junit.jupiter junit-jupiter-engine     | Eclipse Public License v2.0                                        |
-|     org.junit.jupiter junit-jupiter-params     | Eclipse Public License v2.0                                        |
-|     org.junit.vintage junit-vintage-engine     | Eclipse Public License v2.0                                        |
-|           org.postgresql postgresql            | BSD                                                                |
-|            org.testcontainers jdbc             | MIT                                                                |
-|        org.testcontainers junit-jupiter        | MIT                                                                |
-|         org.testcontainers mssqlserver         | MIT                                                                |
-|            org.testcontainers mysql            | MIT                                                                |
-|          org.testcontainers oracle-xe          | MIT                                                                |
-|         org.testcontainers postgresql          | MIT                                                                |
+|               Dependency               | License                                                            |
+|:--------------------------------------:|--------------------------------------------------------------------|
+|     ch.qos.logback logback-classic     | Eclipse Public License 1.0 & GNU Lesser General Public License 2.1 |
+|  com.github.fnoio function-agent-java  | MIT                                                                |
+|  com.github.fnoio grel-functions-java  | MIT                                                                |
+| com.github.fnoio idlab-functions-java  | MIT                                                                |
+|       com.github.rdfhdt hdt-java       | GNU Lesser General Public License v3.0                             |
+|  com.github.tomakehurst:wiremock-jre8  | Apache License 2.0                                                 |
+|   com.google.protobuf protobuf-java    | BSD 3-clause                                                       |
+|   com.microsoft.sqlserver mssql-jdbc   | MIT                                                                |
+|     com.mysql mysql-connector-java     | GNU General Public License v2.0                                    |
+|    com.oracle.database.jdbc:ojdbc11    | Oracle Free Use Terms and Conditions                               |
+|     eu.neverblink.jelly jelly-core     | Apache License 2.0                                                 |
+|    eu.neverblink.jelly jelly-rdf4j     | Apache License 2.0                                                 |
+|         net.minidev json-smart         | Apache License 2.0                                                 |
+|      org.apache.jena fuseki-main       | Apache License 2.0                                                 |
+|     org.eclipse.rdf4j rdf4j-client     | Eclipse Distribution License v1.0                                  |
+|  org.junit.jupiter junit-jupiter-api   | Eclipse Public License v2.0                                        |
+| org.junit.jupiter junit-jupiter-engine | Eclipse Public License v2.0                                        |
+| org.junit.jupiter junit-jupiter-params | Eclipse Public License v2.0                                        |
+| org.junit.vintage junit-vintage-engine | Eclipse Public License v2.0                                        |
+|       org.postgresql postgresql        | BSD                                                                |
+|        org.testcontainers jdbc         | MIT                                                                |
+|    org.testcontainers junit-jupiter    | MIT                                                                |
+|     org.testcontainers mssqlserver     | MIT                                                                |
+|        org.testcontainers mysql        | MIT                                                                |
+|      org.testcontainers oracle-xe      | MIT                                                                |
+|     org.testcontainers postgresql      | MIT                                                                |
 
 ## Commercial Support
 

--- a/buildNumber.properties
+++ b/buildNumber.properties
@@ -1,3 +1,3 @@
 #maven.buildNumber.plugin properties file
-#Sun Jun 08 17:31:20 CEST 2025
-buildNumber0=375
+#Sun Jun 08 18:28:21 CEST 2025
+buildNumber0=378

--- a/buildNumber.properties
+++ b/buildNumber.properties
@@ -1,4 +1,3 @@
 #maven.buildNumber.plugin properties file
-#Tue Aug 13 08:29:04 GMT 2024
-buildNumber0=373
-
+#Sun Jun 08 17:31:20 CEST 2025
+buildNumber0=375

--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,17 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>eu.neverblink.jelly</groupId>
+            <artifactId>jelly-rdf4j</artifactId>
+            <version>3.1.2</version>
+            <exclusions> <!-- Exclude RDF4J, use the version from the rdf4j-client dependency -->
+                <exclusion>
+                    <groupId>org.eclipse.rdf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>be.ugent.idlab.knows</groupId>
             <artifactId>function-agent-java</artifactId>
             <version>1.2.1</version>

--- a/src/main/java/be/ugent/rml/cli/Main.java
+++ b/src/main/java/be/ugent/rml/cli/Main.java
@@ -127,7 +127,7 @@ public class Main {
                 .build();
         Option serializationFormatOption = Option.builder("s")
                 .longOpt("serialization")
-                .desc("serialization format (nquads (default), turtle, trig, trix, jsonld, hdt)")
+                .desc("serialization format (nquads (default), turtle, trig, trix, jsonld, hdt, jelly)")
                 .hasArg()
                 .build();
         Option jdbcDSNOption = Option.builder("dsn")
@@ -545,12 +545,7 @@ public class Main {
                 String serializationFormat = target.getSerializationFormat();
                 OutputStream output = target.getOutputStream();
                 store.addQuads(target.getMetadata());
-
-                // Set character encoding
-                try (Writer out = new BufferedWriter(new OutputStreamWriter(output, Charset.defaultCharset()))) {
-                    // Write store to target
-                    store.write(out, serializationFormat);
-                }
+                store.write(output, serializationFormat);
                 // Close OS resources
                 target.close();
                 logger.debug("Exporting to Target: {}", target);
@@ -637,7 +632,7 @@ public class Main {
             logger.info("{} quad was generated for default Target", store.size());
         }
 
-        Writer out = null;
+        OutputStream out = null;
         try {
 
             String doneMessage = null;
@@ -653,11 +648,11 @@ public class Main {
 
                 doneMessage = "Writing to " + targetFile.getPath() + " is done.";
 
-                out = Files.newBufferedWriter(targetFile.toPath(), StandardCharsets.UTF_8);
+                out = Files.newOutputStream(targetFile.toPath());
 
             } else {
                 isSystemOut = true;
-                out = new BufferedWriter(new OutputStreamWriter(System.out, StandardCharsets.UTF_8));
+                out = System.out;
             }
 
             store.write(out, format);

--- a/src/main/java/be/ugent/rml/store/QuadStore.java
+++ b/src/main/java/be/ugent/rml/store/QuadStore.java
@@ -130,37 +130,15 @@ public abstract class QuadStore {
      * Write out the QuadStore in given format
      * TODO use class or enum for output format
      *
-     * @param out    Writer output location
+     * @param out    OutputStream to write to
      * @param format QuadStore format (.TTL)
      * @throws Exception
      */
-    public abstract void write(Writer out, String format) throws Exception;
+    public abstract void write(OutputStream out, String format) throws Exception;
 
     // END OF ABSTRACT METHODS
 
-    // following final methods use the abstract methods to provide additional functionality or helper functions
-    /**
-     * Helper function
-     *
-     * @param out
-     * @param format
-     * @throws Exception
-     */
-    public final void write(ByteArrayOutputStream out, String format) throws Exception {
-        write(new BufferedWriter(new OutputStreamWriter(out)), format);
-    }
-
-    /**
-     * Helper function
-     *
-     * @param out
-     * @param format
-     * @throws Exception
-     */
-    public final void write(PrintStream out, String format) throws Exception {
-        write(new PrintWriter(out), format);
-    }
-
+    // following final methods use the abstract metho`ds to provide additional functionality or helper functions
     /**
      * Helper function
      *

--- a/src/main/java/be/ugent/rml/store/QuadStore.java
+++ b/src/main/java/be/ugent/rml/store/QuadStore.java
@@ -127,7 +127,20 @@ public abstract class QuadStore {
     public abstract void read(InputStream is, String base, RDFFormat format) throws Exception;
 
     /**
-     * Write out the QuadStore in given format
+     * Write out the QuadStore in given format.
+     * Deprecated, use write(OutputStream out, String format) instead.
+     * TODO remove this method in future versions, use write(OutputStream out, String format) instead.
+     *
+     * @param out    Writer output location
+     * @param format QuadStore format (.TTL)
+     * @throws Exception
+     */
+    @Deprecated
+    public abstract void write(Writer out, String format) throws Exception;
+
+    /**
+     * Write out the QuadStore in given format, using a binary output stream.
+     * Override this method if you want to support binary formats like Jelly.
      * TODO use class or enum for output format
      *
      * @param out    OutputStream to write to
@@ -138,7 +151,18 @@ public abstract class QuadStore {
 
     // END OF ABSTRACT METHODS
 
-    // following final methods use the abstract metho`ds to provide additional functionality or helper functions
+    // following final methods use the abstract methods to provide additional functionality or helper functions
+    /**
+     * Helper function
+     *
+     * @param out
+     * @param format
+     * @throws Exception
+     */
+    public final void write(PrintStream out, String format) throws Exception {
+        write(new PrintWriter(out), format);
+    }
+
     /**
      * Helper function
      *

--- a/src/main/java/be/ugent/rml/store/RDF4JStore.java
+++ b/src/main/java/be/ugent/rml/store/RDF4JStore.java
@@ -4,6 +4,9 @@ import be.ugent.rml.term.BlankNode;
 import be.ugent.rml.term.Literal;
 import be.ugent.rml.term.NamedNode;
 import be.ugent.rml.term.Term;
+import eu.neverblink.jelly.convert.rdf4j.rio.JellyFormat;
+import eu.neverblink.jelly.convert.rdf4j.rio.JellyWriterSettings;
+import eu.neverblink.jelly.core.JellyOptions;
 import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.model.impl.*;
 import org.eclipse.rdf4j.model.util.Models;
@@ -16,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
@@ -149,7 +153,7 @@ public class RDF4JStore extends QuadStore {
     }
 
     @Override
-    public void write(Writer out, String format) throws Exception {
+    public void write(OutputStream out, String format) throws Exception {
         switch (format) {
             case "turtle":
                 Rio.write(model, out, RDFFormat.TURTLE);
@@ -171,6 +175,12 @@ public class RDF4JStore extends QuadStore {
                 break;
             case "ntriples":
                 Rio.write(model, out, RDFFormat.NTRIPLES);
+                break;
+            case "jelly":
+                var settings = JellyWriterSettings.empty();
+                // Mark RDF-star as not used
+                settings.setJellyOptions(JellyOptions.BIG_STRICT);
+                Rio.write(model, out, JellyFormat.JELLY, settings);
                 break;
             default:
                 throw new Exception("Serialization " + format + " not supported");

--- a/src/main/java/be/ugent/rml/store/RDF4JStore.java
+++ b/src/main/java/be/ugent/rml/store/RDF4JStore.java
@@ -18,9 +18,7 @@ import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.Writer;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -153,7 +151,7 @@ public class RDF4JStore extends QuadStore {
     }
 
     @Override
-    public void write(OutputStream out, String format) throws Exception {
+    public void write(Writer out, String format) throws Exception {
         switch (format) {
             case "turtle":
                 Rio.write(model, out, RDFFormat.TURTLE);
@@ -177,13 +175,25 @@ public class RDF4JStore extends QuadStore {
                 Rio.write(model, out, RDFFormat.NTRIPLES);
                 break;
             case "jelly":
-                var settings = JellyWriterSettings.empty();
-                // Mark RDF-star as not used
-                settings.setJellyOptions(JellyOptions.BIG_STRICT);
-                Rio.write(model, out, JellyFormat.JELLY, settings);
-                break;
+                throw new UnsupportedOperationException(
+                    "Writing Jelly format to a Writer is not supported. Use OutputStream instead."
+                );
             default:
                 throw new Exception("Serialization " + format + " not supported");
+        }
+    }
+
+    @Override
+    public void write(OutputStream out, String format) throws Exception {
+        // Jelly is the only format that requires a binary output stream
+        if (format.equals("jelly")) {
+            var settings = JellyWriterSettings.empty();
+            // Mark RDF-star as not used
+            settings.setJellyOptions(JellyOptions.BIG_STRICT);
+            Rio.write(model, out, JellyFormat.JELLY, settings);
+        } else {
+            // For all other formats, fall back to using the Writer
+            write(new BufferedWriter(new OutputStreamWriter(out)), format);
         }
     }
 

--- a/src/main/java/be/ugent/rml/store/SimpleQuadStore.java
+++ b/src/main/java/be/ugent/rml/store/SimpleQuadStore.java
@@ -108,10 +108,10 @@ public class SimpleQuadStore extends QuadStore {
     }
 
     @Override
-    public void write(Writer out, String format) throws IOException {
+    public void write(OutputStream out, String format) throws IOException {
         switch (format) {
             case "nquads":
-                toNQuads(out);
+                toNQuads(new BufferedWriter(new OutputStreamWriter(out)));
                 break;
             default:
                 throw new Error("Serialization " + format + " not supported");

--- a/src/main/java/be/ugent/rml/store/SimpleQuadStore.java
+++ b/src/main/java/be/ugent/rml/store/SimpleQuadStore.java
@@ -108,14 +108,19 @@ public class SimpleQuadStore extends QuadStore {
     }
 
     @Override
-    public void write(OutputStream out, String format) throws IOException {
+    public void write(Writer out, String format) throws IOException {
         switch (format) {
             case "nquads":
-                toNQuads(new BufferedWriter(new OutputStreamWriter(out)));
+                toNQuads(out);
                 break;
             default:
                 throw new Error("Serialization " + format + " not supported");
         }
+    }
+
+    @Override
+    public void write(OutputStream out, String format) throws IOException {
+        write(new BufferedWriter(new OutputStreamWriter(out)), format);
     }
 
     @Override

--- a/src/test/java/be/ugent/rml/ArgumentsTest.java
+++ b/src/test/java/be/ugent/rml/ArgumentsTest.java
@@ -378,6 +378,28 @@ public class ArgumentsTest extends TestCore {
         }
     }
 
+    @Test
+    public void outputJelly() throws Exception {
+        String cwd = Utils.getFile("argument").getAbsolutePath();
+        String mappingFilePath = (new File(cwd, "mapping.ttl")).getAbsolutePath();
+        String actualJellyPath = (new File("./generated_output.jelly")).getAbsolutePath();
+        String expectedJellyPath = Utils.getFile( "argument/output-jelly/target_output.jelly").getAbsolutePath();
+
+        Main.run(new String[]{"-m" , mappingFilePath , "-o" , actualJellyPath , "-s", "jelly"}, cwd);
+        compareFiles(
+                expectedJellyPath,
+                actualJellyPath,
+                false
+        );
+
+        try {
+            File outputFile = Utils.getFile(actualJellyPath);
+            assertTrue(outputFile.delete());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
 
     @Test
     public void quoteInLiteral() throws Exception {

--- a/src/test/java/be/ugent/rml/TestCore.java
+++ b/src/test/java/be/ugent/rml/TestCore.java
@@ -12,6 +12,7 @@ import be.ugent.rml.target.Target;
 import be.ugent.rml.target.TargetFactory;
 import be.ugent.rml.term.NamedNode;
 import be.ugent.rml.term.Term;
+import eu.neverblink.jelly.convert.rdf4j.rio.JellyFormat;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -351,6 +352,8 @@ public abstract class TestCore {
             store = QuadStoreFactory.read(outputFile, RDFFormat.JSONLD);
         } else if (path.endsWith(".trig")) {
             store = QuadStoreFactory.read(outputFile, RDFFormat.TRIG);
+        } else if (path.endsWith(".jelly")) {
+            store = QuadStoreFactory.read(outputFile, JellyFormat.JELLY);
         } else {
             store = QuadStoreFactory.read(outputFile);
         }

--- a/src/test/java/be/ugent/rml/readme/ReadmeFunctionTest.java
+++ b/src/test/java/be/ugent/rml/readme/ReadmeFunctionTest.java
@@ -49,8 +49,7 @@ public class ReadmeFunctionTest {
             QuadStore result = executor.execute(null).get(new NamedNode("rmlmapper://default.store"));
 
             // Output the result
-            BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
-            result.write(out, "turtle");
+            result.write(System.out, "turtle");
         } catch (Exception e) {
             fail("No exception was expected.");
         }

--- a/src/test/java/be/ugent/rml/readme/ReadmeTest.java
+++ b/src/test/java/be/ugent/rml/readme/ReadmeTest.java
@@ -44,8 +44,7 @@ public class ReadmeTest {
             QuadStore result = executor.execute(null).get(new NamedNode("rmlmapper://default.store"));
 
             // Output the result
-            BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
-            result.write(out, "turtle");
+            result.write(System.out, "turtle");
         } catch (Exception e) {
             fail("No exception was expected.");
         }

--- a/src/test/resources/argument/output-jelly/target_output.jelly
+++ b/src/test/resources/argument/output-jelly/target_output.jelly
@@ -1,0 +1,21 @@
+þ
+
+H P–X px
+Rhttp://example.com/10/
+	JVenus
+Rhttp://xmlns.com/foaf/0.1/
+Jname
+
+*Z
+Venusen
+Rhttp://example.com/
+Jid
+
+*Z
+10
+/R-+http://www.w3.org/1999/02/22-rdf-syntax-ns#
+Jtype
+
+JPerson
+
+*J


### PR DESCRIPTION
This PR adds support for outputting files in the [Jelly format](https://w3id.org/jelly), a high-performance binary RDF format based on Protocol Buffers.

- Jelly is a compressed streaming format. Like N-Triples, you can write or read a Jelly file triple-by-triple, without knowing the entire dataset up-front. 
  - This means that a Jelly file can be of essentially infinite size, and the memory usage for writing or parsing such a file would be constant.
- Like HDT, it uses pretty efficient compression, to make the resulting file smaller.
- **Unlike** HDT, it is not indexed, so you can't query the file directly. However, you can parse it very efficiently (up to [15 million triples/s in our benchmarks](https://w3id.org/jelly/dev/performance/rdf4j)).

### Implementation

I used the `jelly-rdf4j` library, which integrates nicely with the RDF4J Rio subsystem. GitHub: https://github.com/Jelly-RDF/jelly-jvm

Jelly is a binary format, so it can't be written to a Java `Writer`. For this reason I added a new `write` method to `QuadStore` that takes as input an `OutputStream`. In modern RDF4J there is really no reason to use a `Writer` for output, as the only legal encoding is UTF-8 anyway, and RDF4J is perfectly happy with writing to a raw binary stream (it should even be faster). But, I assume that the `Writer`-based method must be kept for API compatibility, so for now I made it so that only Jelly uses the native `OutputStream` output. Remaining RDF4J formats can be migrated later by simply replacing the `out` parameter to be `OutputStream` – I already tested that and it works fine.

These changes may be useful later to reduce the hackiness of the current HDT serializer implementation (which currently bypasses `write` with an additional conditional branch), or to add support for other binary formats.

### Tests

I added a test to verify that the output is saved correctly in the Jelly format.

The `target_output.jelly` was generated using [`jelly-cli`](https://github.com/Jelly-RDF/cli) with this command:

```shell
$ jelly-cli rdf to-jelly --opt.rdf-star=false --opt.generalized-statements=false ../output-turtle/target_output.ttl > target_output.jelly
```

### Using the output

You can use [`jelly-cli`](https://github.com/Jelly-RDF/cli) to play around with the generated Jelly files and convert them to other formats. You can also load them into Apache Jena Fuseki by installing [the Jelly plugin for Jena](https://w3id.org/jelly/jelly-jvm/dev/getting-started-plugins/).

### Dependencies

This adds 3 new dependencies, which together weigh around 2 megabytes in JAR form:

- `jelly-core` – generic serialization code for Jelly
- `jelly-rdf4j` – integration of `jelly-core` with RDF4J
- `protobuf-java` – Google's Protobuf library

`protobuf-java` is a very popular library, used in many projects, with a robust security policy. The Jelly libraries are extensively tested (8000+ test cases in the main suite) and have mitigations for [known security risks](https://w3id.org/jelly/dev/specification/serialization/#security-considerations) tested in CI. They are production-grade and are currently being used for example in the [nanopublication services](https://nanopub.net) for inter-service communication.